### PR TITLE
Changed configuration to use invariant culture

### DIFF
--- a/src/Formo.Tests/FormoTests.cs
+++ b/src/Formo.Tests/FormoTests.cs
@@ -326,12 +326,12 @@ namespace Formo.Tests
     {
         public ConfigurationTestBase(string sectionName, bool throwIfNull = false)
         {
-            configuration = new Configuration(sectionName) { ThrowIfNull = throwIfNull };
+            configuration = new Configuration(sectionName, CultureInfo.InvariantCulture) { ThrowIfNull = throwIfNull };
         }
 
         public ConfigurationTestBase(bool throwIfNull = false)
         {
-            configuration = new Configuration { ThrowIfNull = throwIfNull };
+            configuration = new Configuration(CultureInfo.InvariantCulture) { ThrowIfNull = throwIfNull };
         }
 
         protected readonly dynamic configuration;


### PR DESCRIPTION
Changed configuration to use invariant culture, to make tests pass when running tests on different locale.
